### PR TITLE
Light profiles

### DIFF
--- a/galflow/python/__init__.py
+++ b/galflow/python/__init__.py
@@ -7,3 +7,4 @@ from __future__ import print_function
 from galflow.python.convolve import *
 from galflow.python.shear import *
 from galflow.python.transform import *
+from galflow.python.lightprofiles import *

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -64,6 +64,9 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
     if ny is None:
       ny = nx
 
+  if trunc < 0.:
+    raise ValueError("Sersic trunc must be > 0.")
+    
   if half_light_radius is not None:
     if scale_radius is not None:
       raise ValueError("Only one of scale_radius and half_light_radius may be specified,\
@@ -78,8 +81,8 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
     
   if trunc > 0.:
     flux_fraction = integratedflux(trunc, r0, n)
-    if flux_untruncated:
-      flux *= flux_fraction
+    if not flux_untruncated:
+      flux /= flux_fraction
   else:
     flux_fraction = 1.
 
@@ -87,6 +90,8 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
   z = tf.sqrt(tf.cast((x+.5-nx/2)**2 + (y+.5-ny/2)**2, tf.float32))
 
   sersic = tf.exp(-tf.math.pow(z/r0, 1/n))
+  if trunc > 0.:
+    sersic = tf.cast((z<trunc), tf.float32) * sersic
   sersic /= math.pi * r0 * r0 * math.factorial(2.*n)
   sersic *= flux
 

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -17,8 +17,23 @@ fwhm_factor = 2*math.sqrt(2*math.log(2))
 hlr_factor = math.sqrt(2*math.log(2))
 
 def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., nx=None, ny=None):
-  """
-  I(r) = exp(-r^2 /2/sigma^2)
+  """Function for generating a Gaussian profile:
+
+    :math:`I(r) = \exp\left(-\frac{r^2}{2\sigma^2}\right) / (2 \pi \sigma^2)`
+
+  Args:
+    sigma: `float`, sigma of the profile. Typically given in arcsec.
+    fwhm: `float`, full-width-half-max of the profile.  Typically given in arcsec.
+    half_light_radius: `float`, half-light radius of the profile.  Typically given in arcsec.
+    flux: `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
+    nx: `int`, width of the stamp
+    ny: `int`, height of the stamp
+
+  Returns:
+    `Tensor` of shape [nx, ny] of the centered profile
+
+  Example:
+    >>> gaussian(sigma=3., nx=55)
   """
   if nx is None:
     if ny is None:
@@ -52,8 +67,27 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., nx=None, ny
   return gaussian
 
 def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux_untruncated=False, nx=None, ny=None):
-  """
-  I also want specific parameters, see https://galsim-developers.github.io/GalSim/_build/html/sb.html
+  """Function for generating a Sersic profile:
+
+    :math:`I(r) = I0 \exp(-\left(r/r_0\right)^{\frac{1}{n}})`
+    where
+    :math:`I0 = \pi r_0^2 (2n)!`
+
+  Args:
+    n: `int`, Sersic index.
+    half_light_radius: `float`, half-light radius of the profile.  Typically given in arcsec.
+    scale_radius: `float`, scale radius of the profile.  Typically given in arcsec.
+    flux: `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
+    nx: `int`, width of the stamp
+    ny: `int`, height of the stamp
+    trunc: `float`, an optional truncation radius at which the profile is made to drop to zero, in the same units as the size parameter.
+    flux_untruncated: `boolean`, specifies whether the ``flux`` and ``half_light_radius`` specifications correspond to the untruncated profile (``True``) or to the truncated profile (``False``, default)
+
+  Returns:
+    `Tensor` of shape [nx, ny] of the centered profile
+
+  Example:
+    >>> sersic(n=2, scale_radius=5., flux=40., nx=55)
   """
   if nx is None:
     if ny is None:
@@ -66,13 +100,14 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
 
   if trunc < 0.:
     raise ValueError("Sersic trunc must be > 0.")
-    
+
   if half_light_radius is not None:
     if scale_radius is not None:
       raise ValueError("Only one of scale_radius and half_light_radius may be specified,\
         scale_radius={}, half_light_radius={}".format(scale_radius, half_light_radius))
     else:
-      raise NotImplementedError("to implement, see https://github.com/GalSim-developers/GalSim/blob/6c1eb247df86ec03d1a2c9c8024fe57b1bd4a154/src/SBSersic.cpp#L656")
+      raise NotImplementedError("to implement, see\
+        https://github.com/GalSim-developers/GalSim/blob/6c1eb247df86ec03d1a2c9c8024fe57b1bd4a154/src/SBSersic.cpp#L656")
   elif scale_radius is not None:
     r0 = scale_radius
   else:
@@ -98,7 +133,8 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
   return sersic
 
 def integratedflux(trunc, r0, n):
+  """ Convenience function to compute the fraction of the total flux enclosed within a given radius
+  """
   r = trunc / r0
   z = tf.math.pow(r, 1./n)
   return tf.math.igamma(2.*n, z)
-  

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -39,7 +39,7 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., stamp_size=
     
   x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
   # need to check how to properly consider the even and odd stamp sizes
-  z = tf.sqrt(tf.cast((x-tf.math.floor(stamp_size/2))**2 + (y-tf.math.floor(stamp_size/2))**2, tf.float32))
+  z = tf.sqrt(tf.cast((x+.5-stamp_size/2)**2 + (y+.5-stamp_size/2)**2, tf.float32))
   gaussian = flux * tf.exp(-z*z / 2 / sigma/sigma) / 2 / math.pi / sigma / sigma
 
   return gaussian
@@ -70,7 +70,7 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
 
   x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
   # need to check how to properly consider the even and odd stamp sizes
-  z = tf.sqrt(tf.cast((x-tf.math.floor(stamp_size/2))**2 + (y-tf.math.floor(stamp_size/2))**2, tf.float32))
+  z = tf.sqrt(tf.cast((x+.5-stamp_size/2)**2 + (y+.5-stamp_size/2)**2, tf.float32))
 
   sersic = tf.exp(-tf.math.pow(z/r0, 1/n))
   sersic /= math.pi * r0 * r0 * math.factorial(2.*n)

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -16,10 +16,18 @@ fwhm_factor = 2*math.sqrt(2*math.log(2))
 # The half-light-radius is sqrt(2 ln2) sigma
 hlr_factor = math.sqrt(2*math.log(2))
 
-def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., stamp_size=33):
+def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., nx=None, ny=None):
   """
   I(r) = exp(-r^2 /2/sigma^2)
   """
+  if nx is None:
+    if ny is None:
+      raise ValueError("Either nx or ny or both must be specified")
+    else:
+      nx = ny
+  else:
+    if ny is None:
+      ny = nx
 
   if fwhm is not None:
     if half_light_radius is not None or sigma is not None:
@@ -37,17 +45,24 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., stamp_size=
     raise ValueError("One of sigma, fwhm, and half_light_radius must be specified,\
         fwhm={}, half_light_radius={}, sigma={}".format(fwhm, half_light_radius, sigma))
     
-  x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
-  # need to check how to properly consider the even and odd stamp sizes
-  z = tf.sqrt(tf.cast((x+.5-stamp_size/2)**2 + (y+.5-stamp_size/2)**2, tf.float32))
+  x, y = tf.cast(tf.meshgrid(tf.range(nx), tf.range(ny)), tf.float32)
+  z = tf.sqrt(tf.cast((x+.5-nx/2)**2 + (y+.5-ny/2)**2, tf.float32))
   gaussian = flux * tf.exp(-z*z / 2 / sigma/sigma) / 2 / math.pi / sigma / sigma
 
   return gaussian
 
-def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux_untruncated=False, stamp_size=33):
+def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux_untruncated=False, nx=None, ny=None):
   """
   I also want specific parameters, see https://galsim-developers.github.io/GalSim/_build/html/sb.html
   """
+  if nx is None:
+    if ny is None:
+      raise ValueError("Either nx or ny or both must be specified")
+    else:
+      nx = ny
+  else:
+    if ny is None:
+      ny = nx
 
   if half_light_radius is not None:
     if scale_radius is not None:
@@ -68,9 +83,8 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
   else:
     flux_fraction = 1.
 
-  x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
-  # need to check how to properly consider the even and odd stamp sizes
-  z = tf.sqrt(tf.cast((x+.5-stamp_size/2)**2 + (y+.5-stamp_size/2)**2, tf.float32))
+  x, y = tf.cast(tf.meshgrid(tf.range(nx), tf.range(ny)), tf.float32)
+  z = tf.sqrt(tf.cast((x+.5-nx/2)**2 + (y+.5-ny/2)**2, tf.float32))
 
   sersic = tf.exp(-tf.math.pow(z/r0, 1/n))
   sersic /= math.pi * r0 * r0 * math.factorial(2.*n)

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -71,7 +71,7 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux
 
     :math:`I(r) = I0 \exp(-\left(r/r_0\right)^{\frac{1}{n}})`
     where
-    :math:`I0 = \pi r_0^2 (2n)!`
+    :math:`I0 = 1 / (\pi r_0^2 (2n)!)`
 
   Args:
     n: `int`, Sersic index.

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -1,0 +1,85 @@
+# Functions computing light profiles
+# based on https://galsim-developers.github.io/GalSim/_build/html/sb.html
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import tensorflow as tf
+import math
+
+from tensorflow.python.types.core import Value
+
+# The FWHM of a Gaussian is 2 sqrt(2 ln2) sigma
+fwhm_factor = 2*math.sqrt(2*math.log(2))
+# The half-light-radius is sqrt(2 ln2) sigma
+hlr_factor = math.sqrt(2*math.log(2))
+
+def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=1., stamp_size=33):
+  """
+  I(r) = exp(-r^2 /2/sigma^2)
+  """
+
+  if fwhm is not None:
+    if half_light_radius is not None or sigma is not None:
+      raise ValueError("Only one of sigma, fwhm, and half_light_radius may be specified,\
+        fwhm={}, half_light_radius={}, sigma={}".format(fwhm, half_light_radius, sigma))
+    else:
+      sigma = fwhm / fwhm_factor
+  elif half_light_radius is not None:
+    if sigma is not None:
+      raise ValueError("Only one of sigma, fwhm, and half_light_radius may be specified,\
+        fwhm={}, half_light_radius={}, sigma={}".format(fwhm, half_light_radius, sigma))
+    else:
+      sigma = half_light_radius / hlr_factor
+  elif sigma is None:
+    raise ValueError("One of sigma, fwhm, and half_light_radius must be specified,\
+        fwhm={}, half_light_radius={}, sigma={}".format(fwhm, half_light_radius, sigma))
+    
+  x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
+  # need to check how to properly consider the even and odd stamp sizes
+  z = tf.sqrt(tf.cast((x-tf.math.floor(stamp_size/2))**2 + (y-tf.math.floor(stamp_size/2))**2, tf.float32))
+  gaussian = flux * tf.exp(-z*z / 2 / sigma/sigma) / 2 / math.pi / sigma / sigma
+
+  return gaussian
+
+def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0., flux_untruncated=False, stamp_size=33):
+  """
+  I also want specific parameters, see https://galsim-developers.github.io/GalSim/_build/html/sb.html
+  """
+
+  if half_light_radius is not None:
+    if scale_radius is not None:
+      raise ValueError("Only one of scale_radius and half_light_radius may be specified,\
+        scale_radius={}, half_light_radius={}".format(scale_radius, half_light_radius))
+    else:
+      raise NotImplementedError("to implement, see https://github.com/GalSim-developers/GalSim/blob/6c1eb247df86ec03d1a2c9c8024fe57b1bd4a154/src/SBSersic.cpp#L656")
+  elif scale_radius is not None:
+    r0 = scale_radius
+  else:
+    raise ValueError("Either scale_radius or half_light_radius must be specified for Sersic,\
+      half_light_radius={}, scale_radius={}".format(half_light_radius, scale_radius))
+    
+  if trunc > 0.:
+    flux_fraction = integratedflux(trunc, r0, n)
+    if flux_untruncated:
+      flux *= flux_fraction
+  else:
+    flux_fraction = 1.
+
+  x, y = tf.cast(tf.meshgrid(tf.range(stamp_size), tf.range(stamp_size)), tf.float32)
+  # need to check how to properly consider the even and odd stamp sizes
+  z = tf.sqrt(tf.cast((x-tf.math.floor(stamp_size/2))**2 + (y-tf.math.floor(stamp_size/2))**2, tf.float32))
+
+  sersic = tf.exp(-tf.math.pow(z/r0, 1/n))
+  sersic /= math.pi * r0 * r0 * math.factorial(2.*n)
+  sersic *= flux
+
+  return sersic
+
+def integratedflux(trunc, r0, n):
+  r = trunc / r0
+  z = tf.math.pow(r, 1./n)
+  return tf.math.igamma(2.*n, z)
+  

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,65 @@
+import tensorflow as tf
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+import galflow as gf
+import galsim
+
+# Some parameters used for testing Gaussian light profile generation
+stamp_size = 33   # pixel
+sigma = 3.        # arcsec
+hlr = 3.          # arcsec
+fwhm = 3.         # arcsec
+flux = 40.        # photons/cm^2/s
+
+def test_gaussian_profile():
+  """
+  This test generates a simple Gaussian light profile with Galsim and GalFlow,
+  then checks that the same image stamp is recovered
+  """  
+
+  # check sigma input
+  obj = galsim.Gaussian(sigma=sigma)
+  image_galsim_sigma = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galflow_sigma = gf.lightprofiles.gaussian(sigma=sigma, stamp_size=stamp_size)
+
+  # check half_light_radius input
+  obj = galsim.Gaussian(half_light_radius=hlr)
+  image_galsim_hlr = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galflow_hlr = gf.lightprofiles.gaussian(half_light_radius=hlr, stamp_size=stamp_size)
+
+  # check fwhm input
+  obj = galsim.Gaussian(fwhm=fwhm)
+  image_galsim_fwhm = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galflow_fwhm = gf.lightprofiles.gaussian(fwhm=fwhm, stamp_size=stamp_size)
+
+  # check flux input
+  obj = galsim.Gaussian(fwhm=fwhm, flux=flux)
+  image_galsim_flux = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galflow_flux = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, stamp_size=stamp_size)
+
+  assert_allclose(image_galsim_sigma, image_galflow_sigma, atol=1e-5)
+  assert_allclose(image_galsim_hlr, image_galflow_hlr, atol=1e-5)
+  assert_allclose(image_galsim_fwhm, image_galflow_fwhm, atol=1e-5)
+  assert_allclose(image_galsim_flux, image_galflow_flux, atol=1e-5)
+
+# Some parameters used for testing Sersic light profile generation
+stamp_size = 55   # pixel
+scale_radius = 5  # arcsec
+n = 2             
+flux = 40         # photons/cm^2/s
+
+
+def test_sersic_profile():
+  """
+  This test generates a simple Gaussian light profile with Galsim and GalFlow,
+  then checks that the same image stamp is recovered
+  """  
+
+  # check scale_radius input
+  obj = galsim.Sersic(n=n, scale_radius=scale_radius)
+  image_galsim_scale_radius = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galflow_scale_radius = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, stamp_size=stamp_size)
+
+  assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-4)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -84,5 +84,6 @@ def test_sersic_profile():
   image_galflow_trunct = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=True)
 
   assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-4)
+  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-4)
   assert_allclose(image_galsim_truncf, image_galflow_truncf, rtol=1e-4)
   assert_allclose(image_galsim_trunct, image_galflow_trunct, rtol=1e-4)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -59,7 +59,7 @@ trunc = 10.       # arcsec
 
 def test_sersic_profile():
   """
-  This test generates a simple Gaussian light profile with Galsim and GalFlow,
+  This test generates a simple Sersic light profile with Galsim and GalFlow,
   then checks that the same image stamp is recovered
   """  
 
@@ -83,7 +83,7 @@ def test_sersic_profile():
   image_galsim_trunct = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
   image_galflow_trunct = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=True)
 
-  assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-4)
-  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-4)
-  assert_allclose(image_galsim_truncf, image_galflow_truncf, rtol=1e-4)
-  assert_allclose(image_galsim_trunct, image_galflow_trunct, rtol=1e-4)
+  assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-5)
+  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-5)
+  assert_allclose(image_galsim_truncf, image_galflow_truncf, rtol=1e-5)
+  assert_allclose(image_galsim_trunct, image_galflow_trunct, rtol=1e-5)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -55,6 +55,7 @@ stamp_size = 55   # pixel
 scale_radius = 5  # arcsec
 n = 2             
 flux = 40         # photons/cm^2/s
+trunc = 10.       # arcsec
 
 def test_sersic_profile():
   """
@@ -72,5 +73,16 @@ def test_sersic_profile():
   image_galsim_size = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
   image_galflow_size = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1)
 
+  # check truncated profile, flux_untruncated=Flase
+  obj = galsim.Sersic(n=n, scale_radius=scale_radius, trunc=trunc, flux_untruncated=False)
+  image_galsim_truncf = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
+  image_galflow_truncf = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=False)
+  
+  # check truncated profile, flux_untruncated=True
+  obj = galsim.Sersic(n=n, scale_radius=scale_radius, trunc=trunc, flux_untruncated=True)
+  image_galsim_trunct = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
+  image_galflow_trunct = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=True)
+
   assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-4)
-  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-4)
+  assert_allclose(image_galsim_truncf, image_galflow_truncf, rtol=1e-4)
+  assert_allclose(image_galsim_trunct, image_galflow_trunct, rtol=1e-4)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -7,7 +7,7 @@ import galflow as gf
 import galsim
 
 # Some parameters used for testing Gaussian light profile generation
-stamp_size = 33   # pixel
+stamp_size = 33  # pixel
 sigma = 3.        # arcsec
 hlr = 3.          # arcsec
 fwhm = 3.         # arcsec
@@ -22,34 +22,39 @@ def test_gaussian_profile():
   # check sigma input
   obj = galsim.Gaussian(sigma=sigma)
   image_galsim_sigma = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_sigma = gf.lightprofiles.gaussian(sigma=sigma, stamp_size=stamp_size)
+  image_galflow_sigma = gf.lightprofiles.gaussian(sigma=sigma, nx=stamp_size, ny=stamp_size)
 
   # check half_light_radius input
   obj = galsim.Gaussian(half_light_radius=hlr)
   image_galsim_hlr = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_hlr = gf.lightprofiles.gaussian(half_light_radius=hlr, stamp_size=stamp_size)
+  image_galflow_hlr = gf.lightprofiles.gaussian(half_light_radius=hlr, nx=stamp_size, ny=stamp_size)
 
   # check fwhm input
   obj = galsim.Gaussian(fwhm=fwhm)
   image_galsim_fwhm = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_fwhm = gf.lightprofiles.gaussian(fwhm=fwhm, stamp_size=stamp_size)
+  image_galflow_fwhm = gf.lightprofiles.gaussian(fwhm=fwhm, nx=stamp_size, ny=stamp_size)
 
   # check flux input
   obj = galsim.Gaussian(fwhm=fwhm, flux=flux)
   image_galsim_flux = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_flux = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, stamp_size=stamp_size)
+  image_galflow_flux = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, nx=stamp_size, ny=stamp_size)
+
+  # check even and odd stamp sizes
+  obj = galsim.Gaussian(fwhm=fwhm, flux=flux)
+  image_galsim_size = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
+  image_galflow_size = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, nx=stamp_size, ny=stamp_size+1)
 
   assert_allclose(image_galsim_sigma, image_galflow_sigma, atol=1e-5)
   assert_allclose(image_galsim_hlr, image_galflow_hlr, atol=1e-5)
   assert_allclose(image_galsim_fwhm, image_galflow_fwhm, atol=1e-5)
   assert_allclose(image_galsim_flux, image_galflow_flux, atol=1e-5)
+  assert_allclose(image_galsim_size, image_galflow_size, atol=1e-5)
 
 # Some parameters used for testing Sersic light profile generation
 stamp_size = 55   # pixel
 scale_radius = 5  # arcsec
 n = 2             
 flux = 40         # photons/cm^2/s
-
 
 def test_sersic_profile():
   """
@@ -60,6 +65,12 @@ def test_sersic_profile():
   # check scale_radius input
   obj = galsim.Sersic(n=n, scale_radius=scale_radius)
   image_galsim_scale_radius = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_scale_radius = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, stamp_size=stamp_size)
+  image_galflow_scale_radius = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size)
+
+  # check even and odd stamp sizes
+  obj = galsim.Sersic(n=n, scale_radius=scale_radius)
+  image_galsim_size = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
+  image_galflow_size = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1)
 
   assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-4)
+  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-4)


### PR DESCRIPTION
I am opening this PR to follow code updates.

So far, Gaussian profiles are implemented and tested. But only for odd number of stamp sizes.
- [x] test even number of pixels

Idem for Sersic profiles, but also need to take into account truncation:
- [x] test even number of pixels
- [x] test truncation



