### PR TITLE
Enable batches in profile generation

### DIFF
--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -21,27 +21,22 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=None, scale=1.,
   """Function for generating a Gaussian profile:
 
     :math:`I(r) = \exp\left(-\frac{r^2}{2\sigma^2}\right) / (2 \pi \sigma^2)`
-
+  
+  Assuming same stamp size and pixel scale
   Args:
-    
-    /!\
-    /!\ So far assuming same stamp size and pixel scale
-    /!\
-
-    fwhm: `float`, full-width-half-max of the profile.  Typically given in arcsec.
-    half_light_radius: `float`, half-light radius of the profile.  Typically given in arcsec.
-    sigma: `float`, sigma of the profile. Typically given in arcsec.
-    flux: `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
+    fwhm: List of `float`, full-width-half-max of the profile.  Typically given in arcsec.
+    half_light_radius: List of `float`, half-light radius of the profile.  Typically given in arcsec.
+    sigma: List of `float`, sigma of the profile. Typically given in arcsec.
+    flux: List of `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
     scale: `float`, the pixel scale to use for the drawn image
     nx: `int`, width of the stamp
     ny: `int`, height of the stamp
 
-
   Returns:
-    `Tensor` of shape [nx, ny] of the centered profile
+    `Tensor` of shape [batch_size, nx, ny] of the centered profile
 
   Example:
-    >>> gaussian(sigma=3., nx=55)
+    >>> gaussian(sigma=[3.], nx=55)
   """
 
   with tf.name_scope(name or "gaussian"):

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -48,7 +48,6 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=None, scale=1.,
     else:
       if ny is None:
         ny = nx
-
     if fwhm is not None:
       if half_light_radius is not None or sigma is not None:
         raise ValueError("Only one of sigma, fwhm, and half_light_radius may be specified,\
@@ -86,31 +85,28 @@ def gaussian(fwhm=None, half_light_radius=None, sigma=None, flux=None, scale=1.,
 
     return gaussian
 
-def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0.,
-          flux_untruncated=False, scale=1., nx=None, ny=None, name=None):
+def sersic(n, half_light_radius=None, scale_radius=None, flux=None, trunc=None,
+          flux_untruncated=None, scale=1., nx=None, ny=None, name=None):
   """Function for generating a Sersic profile:
-
-    /!\
-    /!\ We want to have things in batch !!!!!!!!!!!!!!!
-    /!\
 
     :math:`I(r) = I0 \exp(-\left(r/r_0\right)^{\frac{1}{n}})`
     where
     :math:`I0 = 1 / (2\pi r_0^2 n \Gamma(2n))`
-
+  
+  Assuming same stamp size and pixel scale
   Args:
-    n: `int`, Sersic index.
-    half_light_radius: `float`, half-light radius of the profile.  Typically given in arcsec.
-    scale_radius: `float`, scale radius of the profile.  Typically given in arcsec.
-    flux: `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
-    trunc: `float`, an optional truncation radius at which the profile is made to drop to zero, in the same units as the size parameter.
-    flux_untruncated: `boolean`, specifies whether the ``flux`` and ``half_light_radius`` specifications correspond to the untruncated profile (``True``) or to the truncated profile (``False``, default)
+    n: List of `int`, Sersic index.
+    half_light_radius: List of `float`, half-light radius of the profile.  Typically given in arcsec.
+    scale_radius: List of `float`, scale radius of the profile.  Typically given in arcsec.
+    flux: List of `float`, flux (in photons/cm^2/s) of the profile. [default: 1]
+    trunc: List of `float`, an optional truncation radius at which the profile is made to drop to zero, in the same units as the size parameter.
+    flux_untruncated: List of `boolean`, specifies whether the ``flux`` and ``half_light_radius`` specifications correspond to the untruncated profile (``True``) or to the truncated profile (``False``, default)
     scale: `float`, the pixel scale to use for the drawn image
     nx: `int`, width of the stamp
     ny: `int`, height of the stamp
 
   Returns:
-    `Tensor` of shape [nx, ny] of the centered profile
+    `Tensor` of shape [batch_size, nx, ny] of the centered profile
 
   Example:
     >>> sersic(n=2, scale_radius=5., flux=40., nx=55)
@@ -124,39 +120,65 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=1., trunc=0.,
     else:
       if ny is None:
         ny = nx
+    
+    if n is None:
+      raise ValueError("Sersic index n must be specified")
+    else:
+      n = tf.convert_to_tensor(n, dtype=tf.float32)
+      batch_size = n.shape[0]
 
-    if trunc < 0.:
-      raise ValueError("Sersic trunc must be > 0.")
+    if trunc is not None:
+      trunc = tf.convert_to_tensor(trunc, dtype=tf.float32)
+      if True in (trunc < 0.):
+        raise ValueError("Sersic trunc must be > 0.")
+    else:
+      trunc = tf.zeros(batch_size)
+
+    if flux_untruncated is None:
+      flux_untruncated = tf.cast(tf.zeros(batch_size), tf.bool)
+    else:  
+      flux_untruncated = tf.convert_to_tensor(flux_untruncated, dtype=tf.bool)
 
     if half_light_radius is not None:
       if scale_radius is not None:
         raise ValueError("Only one of scale_radius and half_light_radius may be specified,\
           scale_radius={}, half_light_radius={}".format(scale_radius, half_light_radius))
       else:
-        if trunc==0. or flux_untruncated:
-          r0 = half_light_radius / calculateHLRFactor(n, 0.)
-        else:
-          raise NotImplementedError("to implement, see\
-          https://github.com/GalSim-developers/GalSim/blob/6c1eb247df86ec03d1a2c9c8024fe57b1bd4a154/src/SBSersic.cpp#L656")
+        half_light_radius = tf.convert_to_tensor(half_light_radius, dtype=tf.float32)
+        normalize = tf.cast(tf.math.logical_or(trunc==0., flux_untruncated), tf.float32)
+        r0 = half_light_radius * (1-normalize) + normalize * half_light_radius / calculateHLRFactor(n, 0.)
     elif scale_radius is not None:
+      scale_radius = tf.convert_to_tensor(scale_radius, dtype=tf.float32)
       r0 = scale_radius
     else:
       raise ValueError("Either scale_radius or half_light_radius must be specified for Sersic,\
         half_light_radius={}, scale_radius={}".format(half_light_radius, scale_radius))
-      
-    if trunc > 0.:
-      flux_fraction = integratedflux(trunc, r0, n)
-      if not flux_untruncated:
-        flux /= flux_fraction
-    else:
-      flux_fraction = 1.
+
+    if flux is None:
+      flux = tf.ones(batch_size)
+    else:  
+      flux = tf.convert_to_tensor(flux, dtype=tf.float32)
+
+    flux_fraction = integratedflux(trunc, r0, n)
+    normalize = tf.cast(tf.math.logical_and(trunc > 0., tf.math.logical_not(flux_untruncated)), tf.float32)
+    flux = flux * (1-normalize) + flux / flux_fraction * normalize
 
     x, y = tf.cast(tf.meshgrid(tf.range(nx), tf.range(ny)), tf.float32)
+    x = tf.repeat(tf.expand_dims(x, 0), batch_size, axis=0)
+    y = tf.repeat(tf.expand_dims(y, 0), batch_size, axis=0)
+
     z = tf.sqrt(tf.cast((x+.5-nx/2)**2 + (y+.5-ny/2)**2, tf.float32)) * scale
 
+    n = tf.reshape(n, (batch_size, 1, 1))
+    flux = tf.reshape(flux, (batch_size, 1, 1))
+    r0 = tf.reshape(r0, (batch_size, 1, 1))
+    trunc = tf.reshape(trunc, (batch_size, 1, 1))
+
     sersic = tf.exp(-tf.math.pow(z/r0, 1/n))  * scale  * scale
-    if trunc > 0.:
-      sersic = tf.cast((z<trunc), tf.float32) * sersic
+    
+    trunc = trunc * tf.cast(trunc>0., tf.float32) + tf.math.sqrt(nx*nx*1.+ny*ny*1.) * scale * tf.cast(trunc==0., tf.float32)
+    sersic = tf.cast((z<trunc), tf.float32) * sersic
+
     sersic /= 2 * math.pi * r0 * r0 * n * tf.math.exp(tf.math.lgamma(2.*n))
     sersic *= flux
 
@@ -167,29 +189,37 @@ def integratedflux(trunc, r0, n):
   """
   r = trunc / r0
   z = tf.math.pow(r, 1./n)
-  return tf.math.igamma(2.*n, z)
+  return tf.math.igamma(2.*n, z) * tf.cast(trunc>0., tf.float32) + tf.ones(n.shape[0]) *  tf.cast(trunc==0., tf.float32)
 
 def calculate_b(n):
-  """Find the solution to gamma(2n; b_n) = Gamma(2n)/2 
+  """
+  Args:
+    n: List of `float`
+
+  Return:
+    b_n
+
+  Find the solution to gamma(2n; b_n) = Gamma(2n)/2 
   Start with approximation from Ciotti & Bertin, 1999:
   b ~= 2n - 1/3 + 4/(405n) + 46/(25515n^2) + 131/(1148175n^3) - ...
   Then, use a Broyden solver
   """
-  n = tf.cast(n, tf.float32)
+  n = tf.convert_to_tensor(n, dtype=tf.float32)
   b1 = 2.*n-1./3.
   b2 = b1 + (8./405.)*(1./n) + (46./25515.)*(1./n/n) + (131./1148175.)*(1./n/n/n)
 
   def func(b):
     return 2.*tf.math.igamma(2*n, b) - 1.
 
-  def update(z, zprev):
+  def update(z, zprev, not_done):
     fp_z = (func(z) - func(zprev)) / (z - zprev)
-    return z - func(z)/fp_z
+    return z - func(z)/fp_z * tf.cast(not_done, tf.float32)
   
   def Broyden_solver(b2, b1):
-    z_prev, z = b2, update(b2, b1)
-    while func(z) > 1e-5:
-      z_prev, z = z, update(z, z_prev)
+    z_prev, z = b2, update(b2, b1, tf.cast(tf.ones(b2.shape[0]), tf.bool))
+    while not tf.reduce_all(func(z) < 1e-5):
+      not_done = func(z) > 1e-5
+      z_prev, z = z, update(z, z_prev, not_done)
     return z
   
   return Broyden_solver(b2,b1)

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -98,7 +98,7 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=None, trunc=None,
   
   Assuming same stamp size and pixel scale
   Args:
-    n: List of `int`, Sersic index.
+    n: List of `float`, Sersic index.
     half_light_radius: List of `float`, half-light radius of the profile.  Typically given in arcsec.
     scale_radius: List of `float`, scale radius of the profile.  Typically given in arcsec.
     flux: List of `float`, flux (in photons/cm^2/s) of the profile. [default: 1]

--- a/galflow/python/lightprofiles.py
+++ b/galflow/python/lightprofiles.py
@@ -112,7 +112,7 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=None, trunc=None,
     `Tensor` of shape [batch_size, nx, ny] of the centered profile
 
   Example:
-    >>> sersic(n=2, scale_radius=5., flux=40., nx=55)
+    >>> sersic(n=[2.], scale_radius=[5.], flux=[40.], nx=55)
   """
   with tf.name_scope(name or "sersic"):
     if nx is None:
@@ -169,7 +169,7 @@ def sersic(n, half_light_radius=None, scale_radius=None, flux=None, trunc=None,
     x, y = tf.meshgrid(tf.range(nx), tf.range(ny))
     x = tf.cast(x, tf.float32)
     y = tf.cast(y, tf.float32)
-    
+
     x = tf.repeat(tf.expand_dims(x, 0), batch_size, axis=0)
     y = tf.repeat(tf.expand_dims(y, 0), batch_size, axis=0)
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -79,8 +79,8 @@ def test_calculate_b():
   """
   b_m = [1.67834699, 3.67206075, 5.67016119, 7.66924944, 9.66871461, 11.6683632,
          13.6681146,  15.6679295,  17.6677864, 19.6676724]
-  for m in range(1,11):
-    assert_allclose(gf.lightprofiles.calculate_b(m), b_m[m-1], atol=1e-4)
+  m = tf.cast(tf.range(1, 11), tf.float32)
+  assert_allclose(gf.lightprofiles.calculate_b(m), b_m, atol=1e-4)
 
 def test_sersic_profile():
   """This test generates a simple Sersic light profile with Galsim and GalFlow,
@@ -90,36 +90,36 @@ def test_sersic_profile():
   # check scale_radius input
   obj = galsim.Sersic(n=n, scale_radius=scale_radius)
   image_galsim_scale_radius = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_scale_radius = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size)
+  image_galflow_scale_radius = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size)[0,...]
 
   # check half_light_radius input
   obj = galsim.Sersic(n=n, half_light_radius=hlr, flux=flux)
   image_galsim_hlr = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_hlr = gf.lightprofiles.sersic(n=n, half_light_radius=hlr, nx=stamp_size, flux=flux)
+  image_galflow_hlr = gf.lightprofiles.sersic(n=[n], half_light_radius=[hlr], nx=stamp_size, flux=flux)[0,...]
 
   # check scale input
   obj = galsim.Sersic(n=n, half_light_radius=hlr, flux=flux)
   image_galsim_scale = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=scale, method='no_pixel').array
-  image_galflow_scale = gf.lightprofiles.sersic(n=n, half_light_radius=hlr, nx=stamp_size, flux=flux, scale=scale)
+  image_galflow_scale = gf.lightprofiles.sersic(n=[n], half_light_radius=[hlr], nx=stamp_size, flux=[flux], scale=scale)[0,...]
 
   # check even and odd stamp sizes
   obj = galsim.Sersic(n=n, scale_radius=scale_radius)
   image_galsim_size = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
-  image_galflow_size = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1)
+  image_galflow_size = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size, ny=stamp_size+1)[0,...]
 
   # check truncated profile, flux_untruncated=Flase
   obj = galsim.Sersic(n=n, scale_radius=scale_radius, trunc=trunc, flux_untruncated=False)
   image_galsim_truncf = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
-  image_galflow_truncf = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=False)
+  image_galflow_truncf = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size, ny=stamp_size+1, trunc=[trunc], flux_untruncated=[False])[0,...]
   
   # check truncated profile, flux_untruncated=True
   obj = galsim.Sersic(n=n, scale_radius=scale_radius, trunc=trunc, flux_untruncated=True)
   image_galsim_trunct = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
-  image_galflow_trunct = gf.lightprofiles.sersic(n=n, scale_radius=scale_radius, nx=stamp_size, ny=stamp_size+1, trunc=trunc, flux_untruncated=True)
+  image_galflow_trunct = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size, ny=stamp_size+1, trunc=[trunc], flux_untruncated=[True])[0,...]
 
   assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-5)
   assert_allclose(image_galsim_hlr, image_galflow_hlr, rtol=1e-5)
-  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-5)
   assert_allclose(image_galsim_scale, image_galflow_scale, rtol=1e-5)
+  assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-5)
   assert_allclose(image_galsim_truncf, image_galflow_truncf, rtol=1e-5)
   assert_allclose(image_galsim_trunct, image_galflow_trunct, rtol=1e-5)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -92,6 +92,15 @@ def test_sersic_profile():
   image_galsim_scale_radius = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
   image_galflow_scale_radius = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size)[0,...]
 
+  # check batch input
+  obj1 = galsim.Sersic(n=n, scale_radius=scale_radius)
+  obj2 = galsim.Sersic(n=n*2, scale_radius=scale_radius*2)
+  image_galsim_batch1 = obj1.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galsim_batch2 = obj2.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galsim_batch = np.stack([image_galsim_batch1, image_galsim_batch2], axis=0)
+  image_galflow_batch = gf.lightprofiles.sersic(n=[n, n*2.], scale_radius=[scale_radius, scale_radius*2.], nx=stamp_size)
+
+
   # check half_light_radius input
   obj = galsim.Sersic(n=n, half_light_radius=hlr, flux=flux)
   image_galsim_hlr = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
@@ -118,6 +127,7 @@ def test_sersic_profile():
   image_galflow_trunct = gf.lightprofiles.sersic(n=[n], scale_radius=[scale_radius], nx=stamp_size, ny=stamp_size+1, trunc=[trunc], flux_untruncated=[True])[0,...]
 
   assert_allclose(image_galsim_scale_radius, image_galflow_scale_radius, rtol=1e-5)
+  assert_allclose(image_galsim_batch, image_galflow_batch, atol=1e-5)
   assert_allclose(image_galsim_hlr, image_galflow_hlr, rtol=1e-5)
   assert_allclose(image_galsim_scale, image_galflow_scale, rtol=1e-5)
   assert_allclose(image_galsim_size, image_galflow_size, rtol=1e-5)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -22,34 +22,43 @@ def test_gaussian_profile():
   # check sigma input
   obj = galsim.Gaussian(sigma=sigma)
   image_galsim_sigma = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_sigma = gf.lightprofiles.gaussian(sigma=sigma, nx=stamp_size, ny=stamp_size)
+  image_galflow_sigma = gf.lightprofiles.gaussian(sigma=[sigma], nx=stamp_size, ny=stamp_size)[0,...]
+
+  # check batch input
+  obj1 = galsim.Gaussian(sigma=sigma)
+  obj2 = galsim.Gaussian(sigma=sigma*2)
+  image_galsim_batch1 = obj1.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galsim_batch2 = obj2.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
+  image_galsim_batch = np.stack([image_galsim_batch1, image_galsim_batch2], axis=0)
+  image_galflow_batch = gf.lightprofiles.gaussian(sigma=[sigma, sigma*2], nx=stamp_size, ny=stamp_size)
 
   # check half_light_radius input
   obj = galsim.Gaussian(half_light_radius=hlr)
   image_galsim_hlr = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_hlr = gf.lightprofiles.gaussian(half_light_radius=hlr, nx=stamp_size, ny=stamp_size)
+  image_galflow_hlr = gf.lightprofiles.gaussian(half_light_radius=[hlr], nx=stamp_size, ny=stamp_size)[0,...]
 
   # check fwhm input
   obj = galsim.Gaussian(fwhm=fwhm)
   image_galsim_fwhm = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_fwhm = gf.lightprofiles.gaussian(fwhm=fwhm, nx=stamp_size, ny=stamp_size)
+  image_galflow_fwhm = gf.lightprofiles.gaussian(fwhm=[fwhm], nx=stamp_size, ny=stamp_size)[0,...]
 
   # check fwhm input
   obj = galsim.Gaussian(fwhm=fwhm)
   image_galsim_scale = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=scale, method='no_pixel').array
-  image_galflow_scale = gf.lightprofiles.gaussian(fwhm=fwhm, nx=stamp_size, ny=stamp_size, scale=scale)
+  image_galflow_scale = gf.lightprofiles.gaussian(fwhm=[fwhm], nx=stamp_size, ny=stamp_size, scale=scale)[0,...]
 
   # check flux input
   obj = galsim.Gaussian(fwhm=fwhm, flux=flux)
   image_galsim_flux = obj.drawImage(nx=stamp_size, ny=stamp_size, scale=1., method='no_pixel').array
-  image_galflow_flux = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, nx=stamp_size, ny=stamp_size)
+  image_galflow_flux = gf.lightprofiles.gaussian(fwhm=[fwhm], flux=[flux], nx=stamp_size, ny=stamp_size)[0,...]
 
   # check even and odd stamp sizes
   obj = galsim.Gaussian(fwhm=fwhm, flux=flux)
   image_galsim_size = obj.drawImage(nx=stamp_size, ny=stamp_size+1, scale=1., method='no_pixel').array
-  image_galflow_size = gf.lightprofiles.gaussian(fwhm=fwhm, flux=flux, nx=stamp_size, ny=stamp_size+1)
+  image_galflow_size = gf.lightprofiles.gaussian(fwhm=[fwhm], flux=[flux], nx=stamp_size, ny=stamp_size+1)[0,...]
 
   assert_allclose(image_galsim_sigma, image_galflow_sigma, atol=1e-5)
+  assert_allclose(image_galsim_batch, image_galflow_batch, atol=1e-5)
   assert_allclose(image_galsim_hlr, image_galflow_hlr, atol=1e-5)
   assert_allclose(image_galsim_fwhm, image_galflow_fwhm, atol=1e-5)
   assert_allclose(image_galsim_scale, image_galflow_scale, rtol=1e-5)


### PR DESCRIPTION
With this PR, we are now able to generate Gaussian and Sersic profiles by batch. The only requirement is to provide parameters by list of floats, tensors or numpy arrays (which are then converted in TF tensors).

An example can be seen at https://github.com/b-remy/gems/blob/main/toymodel1.py ([752107e](https://github.com/b-remy/gems/commit/752107e903759d10f845e5f4be929c740ad49b11)):

![Figure_2](https://user-images.githubusercontent.com/30293694/134220784-5d55a9c7-7f0c-4ee4-bf15-b2e9766bac75.png)
